### PR TITLE
SystemUI: Allow limiting AOD & ambient display refresh rate via overlay.

### DIFF
--- a/packages/SystemUI/res/values/custom_config.xml
+++ b/packages/SystemUI/res/values/custom_config.xml
@@ -53,5 +53,8 @@
 
     <!-- Whether show refresh rate QS tile -->
     <bool name="config_showRefreshRateQsTile">false</bool>
-    
+
+    <!-- Preferred max refresh rate at AOD & Ambient Display, if supported by the display. -->
+    <integer name="config_aodMaxRefreshRate">-1</integer>
+
 </resources>


### PR DESCRIPTION
 This should save some juice while showing it. AOSP has
 implementation for keyguard & AOD but lack AOD only - We still want to show
 keyguard at max rate to allow better UX

This feature should behave fine with config_keyguardMaxRefreshRate and/or config_keyguardPrefferedRefreshRate set and thus allows setting a different rate for each

Suggested-by: John Galt <johngaltfirstrun@gmail.com>
Change-Id: If9ed78f15805070524fc524425431107fd015df9
Signed-off-by: mukesh22584 <mks22584@gmail.com>

 Conflicts:
	packages/SystemUI/res/values/custom_config.xml